### PR TITLE
Add dark theme based on QDarkStyle package

### DIFF
--- a/foundry/gui/MainWindow.py
+++ b/foundry/gui/MainWindow.py
@@ -111,8 +111,9 @@ class MainWindow(QMainWindow):
         super(MainWindow, self).__init__()
 
         self.setWindowIcon(icon("foundry.ico"))
+        self.setStyleSheet(SETTINGS["gui_style"])
 
-        file_menu = QMenu("File")
+        file_menu = QMenu("File", self)
 
         open_rom_action = file_menu.addAction("&Open ROM")
         open_rom_action.triggered.connect(self.on_open_rom)
@@ -139,7 +140,7 @@ class MainWindow(QMainWindow):
         """
         file_menu.addSeparator()
         settings_action = file_menu.addAction("&Settings")
-        settings_action.triggered.connect(show_settings)
+        settings_action.triggered.connect(lambda: show_settings(self))
         file_menu.addSeparator()
         exit_action = file_menu.addAction("&Exit")
         exit_action.triggered.connect(lambda _: self.close())
@@ -159,7 +160,7 @@ class MainWindow(QMainWindow):
         edit_menu.Append(ID_LIMIT_SIZE, "&Limit Size", "")
         """
 
-        self.level_menu = QMenu("Level")
+        self.level_menu = QMenu("Level", self)
 
         self.select_level_action = self.level_menu.addAction("&Select Level")
         self.select_level_action.triggered.connect(self.open_level_selector)
@@ -174,7 +175,7 @@ class MainWindow(QMainWindow):
 
         self.menuBar().addMenu(self.level_menu)
 
-        self.object_menu = QMenu("Objects")
+        self.object_menu = QMenu("Objects", self)
 
         view_blocks_action = self.object_menu.addAction("&View Blocks")
         view_blocks_action.triggered.connect(self.on_block_viewer)
@@ -186,7 +187,7 @@ class MainWindow(QMainWindow):
 
         self.menuBar().addMenu(self.object_menu)
 
-        self.view_menu = QMenu("View")
+        self.view_menu = QMenu("View", self)
         self.view_menu.triggered.connect(self.on_menu)
 
         action = self.view_menu.addAction("Mario")
@@ -254,7 +255,7 @@ class MainWindow(QMainWindow):
 
         self.menuBar().addMenu(self.view_menu)
 
-        help_menu = QMenu("Help")
+        help_menu = QMenu("Help", self)
         """
         help_menu.Append(ID_ENEMY_COMPATIBILITY, "&Enemy Compatibility", "")
         help_menu.Append(ID_TROUBLESHOOTING, "&Troubleshooting", "")
@@ -378,7 +379,7 @@ class MainWindow(QMainWindow):
         self.menu_toolbar.setOrientation(Qt.Horizontal)
         self.menu_toolbar.setIconSize(QSize(20, 20))
 
-        self.menu_toolbar.addAction(icon("settings.svg"), "Editor Settings").triggered.connect(show_settings)
+        self.menu_toolbar.addAction(icon("settings.svg"), "Editor Settings").triggered.connect(lambda: show_settings(self))
         self.menu_toolbar.addSeparator()
         self.menu_toolbar.addAction(icon("folder.svg"), "Open ROM").triggered.connect(self.on_open_rom)
         self.menu_toolbar.addAction(icon("save.svg"), "Save Level").triggered.connect(self.on_save_rom)

--- a/foundry/gui/settings.py
+++ b/foundry/gui/settings.py
@@ -1,9 +1,15 @@
 import json
+import qdarkstyle
 
 from foundry import default_settings_path
 
 RESIZE_LEFT_CLICK = "LMB"
 RESIZE_RIGHT_CLICK = "RMB"
+
+GUI_STYLE = {
+    "RETRO": lambda: "",
+    "DRACULA": lambda: qdarkstyle.load_stylesheet(),
+}
 
 SETTINGS = dict()
 SETTINGS["instaplay_emulator"] = "fceux"
@@ -11,6 +17,7 @@ SETTINGS["instaplay_arguments"] = "%f"
 SETTINGS["default_powerup"] = 0
 
 SETTINGS["resize_mode"] = RESIZE_LEFT_CLICK
+SETTINGS["gui_style"] = "" # initially blank, since we can't call load_stylesheet until the app is started
 
 SETTINGS["draw_mario"] = True
 SETTINGS["draw_jumps"] = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 PySide2>=5.15.0
+QDarkStyle~=2.8.1


### PR DESCRIPTION
# Overview
Closes #62 .

This pull request implements a dark window theme based on the QDarkStyle Python package.

# Added Dependencies

This adds a dependency on the QDarkStyle Python package, but in tests `pyinstaller` works just fine to include it along with the executable build.

# Overall Design

`settings.py` has been given a `GUI_STYLE` dictionary that now defines callables for each window theme, keyed on the theme name. The actual setting that is saved is a string keyed on `gui_style`. The `gui_style` key defaults to the empty string, which causes the normal stylesheets to be set up (providing a light window theme).

The `SettingsDialog` has a new section for `GUI`, allowing the user to select a radio button for the GUI style. The current options are "Retro" (default) and "Dracula" (the dark theme provided by QDarkStyle).

# Relevant Technical Details

The existing `QMenu` constructors within `MainWindow.py` have had a `parent` argument added to them in order to ensure they inherit the current stylesheet.

A `parent` argument was also added to the `SettingsDialog` object creation in order to set the stylesheet appropriately when the user toggles the radio buttons for the "RETRO" or "DRACULA" window theme.


