### PR TITLE
Parse iNES header and use the relevant sizes

### DIFF
--- a/foundry/game/File.py
+++ b/foundry/game/File.py
@@ -1,7 +1,7 @@
 from os.path import basename
 from typing import List, Optional
 
-from smb3parse.constants import BASE_OFFSET, PAGE_A000_ByTileset, Map_TSA_Index
+from smb3parse.constants import BASE_OFFSET, PAGE_A000_ByTileset, WORLD_MAP_TSA_INDEX
 from smb3parse.util.rom import Rom, INESHeader
 
 WORLD_COUNT = 9  # includes warp zone
@@ -52,7 +52,7 @@ class ROM(Rom):
             # and drawing the initial map via Map_Reload_with_Completions.
             # Therefore, the PAGE_A000_ByTileset doesn't have the TSA data for
             # the map tiles.
-            tsa_index = Map_TSA_Index
+            tsa_index = WORLD_MAP_TSA_INDEX
 
         # INES header size + (bank with tsa data * sizeof(bank))
         tsa_start = BASE_OFFSET + tsa_index * TSA_TABLE_INTERVAL
@@ -104,11 +104,12 @@ class ROM(Rom):
 
     def get_byte(self, position: int) -> int:
         position = self.prg_normalize(position)
+
         if position < len(ROM.rom_data):
             return ROM.rom_data[position]
+
         raise IndexError(
-            "Attempted to read from offset 0x{:X} "
-            "when ROM is only of size 0x{:X}".format(position, len(ROM.rom_data))
+            f"Attempted to read from offset 0x{position:X} when ROM is only of size 0x{len(ROM.rom_data):X}"
         )
 
     def bulk_read(self, count: int, position: int) -> bytearray:

--- a/foundry/game/File.py
+++ b/foundry/game/File.py
@@ -2,7 +2,7 @@ from ctypes import Structure, sizeof, addressof, memmove, c_char, c_ubyte
 from os.path import basename
 from typing import List, Optional
 
-from smb3parse.constants import BASE_OFFSET, PAGE_A000_ByTileset
+from smb3parse.constants import BASE_OFFSET, PAGE_A000_ByTileset, Map_TSA_Index
 from smb3parse.util.rom import Rom
 
 WORLD_COUNT = 9  # includes warp zone
@@ -96,7 +96,7 @@ class ROM(Rom):
             # and drawing the initial map via Map_Reload_with_Completions.
             # Therefore, the PAGE_A000_ByTileset doesn't have the TSA data for
             # the map tiles.
-            tsa_index = 12
+            tsa_index = Map_TSA_Index
 
         # INES header size + (bank with tsa data * sizeof(bank))
         tsa_start = BASE_OFFSET + tsa_index * TSA_TABLE_INTERVAL

--- a/foundry/game/File.py
+++ b/foundry/game/File.py
@@ -106,7 +106,10 @@ class ROM(Rom):
         position = self.prg_normalize(position)
         if position < len(ROM.rom_data):
             return ROM.rom_data[position]
-        raise IndexError("Attempted to read from offset 0x{:X} when ROM is only of size 0x{:X}".format(position, len(ROM.rom_data)))
+        raise IndexError(
+            "Attempted to read from offset 0x{:X} "
+            "when ROM is only of size 0x{:X}".format(position, len(ROM.rom_data))
+        )
 
     def bulk_read(self, count: int, position: int) -> bytearray:
         position = self.prg_normalize(position)

--- a/foundry/game/gfx/GraphicsSet.py
+++ b/foundry/game/gfx/GraphicsSet.py
@@ -53,8 +53,10 @@ class GraphicsSet:
 
     def __init__(self, graphic_set_number):
         if not self.GRAPHIC_SET_BG_PAGE_1:
-            self.GRAPHIC_SET_BG_PAGE_1 = ROM().bulk_read(BG_PAGE_COUNT, Level_BG_Pages1)
-            self.GRAPHIC_SET_BG_PAGE_2 = ROM().bulk_read(BG_PAGE_COUNT, Level_BG_Pages2)
+            # Level_BG_Pages1 and 2 are offsets into bank 30, so they need
+            # to be normalized based on the current ROM's PRG size
+            self.GRAPHIC_SET_BG_PAGE_1 = ROM().bulk_read(BG_PAGE_COUNT, ROM.prg_normalize(Level_BG_Pages1))
+            self.GRAPHIC_SET_BG_PAGE_2 = ROM().bulk_read(BG_PAGE_COUNT, ROM.prg_normalize(Level_BG_Pages2))
 
         self.data = bytearray()
         self.number = graphic_set_number
@@ -88,7 +90,8 @@ class GraphicsSet:
             self._read_in_chr_rom_segment(segment)
 
     def _read_in_chr_rom_segment(self, index):
-        offset = CHR_ROM_OFFSET + index * CHR_ROM_SEGMENT_SIZE
+        # CHR_ROM_OFFSET assumes a vanilla ROM PRG size, so normalize it
+        offset = ROM.prg_normalize(CHR_ROM_OFFSET) + index * CHR_ROM_SEGMENT_SIZE
         chr_rom_data = ROM().bulk_read(2 * CHR_ROM_SEGMENT_SIZE, offset)
 
         self.data.extend(chr_rom_data)

--- a/foundry/game/gfx/GraphicsSet.py
+++ b/foundry/game/gfx/GraphicsSet.py
@@ -53,10 +53,8 @@ class GraphicsSet:
 
     def __init__(self, graphic_set_number):
         if not self.GRAPHIC_SET_BG_PAGE_1:
-            # Level_BG_Pages1 and 2 are offsets into bank 30, so they need
-            # to be normalized based on the current ROM's PRG size
-            self.GRAPHIC_SET_BG_PAGE_1 = ROM().bulk_read(BG_PAGE_COUNT, ROM.prg_normalize(Level_BG_Pages1))
-            self.GRAPHIC_SET_BG_PAGE_2 = ROM().bulk_read(BG_PAGE_COUNT, ROM.prg_normalize(Level_BG_Pages2))
+            self.GRAPHIC_SET_BG_PAGE_1 = ROM().bulk_read(BG_PAGE_COUNT, Level_BG_Pages1)
+            self.GRAPHIC_SET_BG_PAGE_2 = ROM().bulk_read(BG_PAGE_COUNT, Level_BG_Pages2)
 
         self.data = bytearray()
         self.number = graphic_set_number
@@ -90,8 +88,7 @@ class GraphicsSet:
             self._read_in_chr_rom_segment(segment)
 
     def _read_in_chr_rom_segment(self, index):
-        # CHR_ROM_OFFSET assumes a vanilla ROM PRG size, so normalize it
-        offset = ROM.prg_normalize(CHR_ROM_OFFSET) + index * CHR_ROM_SEGMENT_SIZE
+        offset = CHR_ROM_OFFSET + index * CHR_ROM_SEGMENT_SIZE
         chr_rom_data = ROM().bulk_read(2 * CHR_ROM_SEGMENT_SIZE, offset)
 
         self.data.extend(chr_rom_data)

--- a/smb3parse/constants.py
+++ b/smb3parse/constants.py
@@ -2120,6 +2120,7 @@ Map_SpriteRAM_Offset = 0x1753F
 Map_StateNothing = 0x14D49
 Map_Tile_ColorSets = 0x1842D
 Map_Tile_Layouts = 0x185A8
+Map_TSA_Index = 12
 Map_Unused7EEA_Vals = 0x16018
 Map_W8D_XOffTable = 0x153B1
 Map_W8D_YOffTable = 0x153B5

--- a/smb3parse/constants.py
+++ b/smb3parse/constants.py
@@ -3,6 +3,8 @@ from typing import Union
 
 BASE_OFFSET = 0x10  # the size of the rom header identifying the rom
 
+WORLD_MAP_TSA_INDEX = 12
+
 TILE_LEVEL_1 = 0x03
 TILE_LEVEL_2 = 0x04
 TILE_LEVEL_3 = 0x05
@@ -2120,7 +2122,6 @@ Map_SpriteRAM_Offset = 0x1753F
 Map_StateNothing = 0x14D49
 Map_Tile_ColorSets = 0x1842D
 Map_Tile_Layouts = 0x185A8
-Map_TSA_Index = 12
 Map_Unused7EEA_Vals = 0x16018
 Map_W8D_XOffTable = 0x153B1
 Map_W8D_YOffTable = 0x153B5

--- a/smb3parse/tests/conftest.py
+++ b/smb3parse/tests/conftest.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 
 from smb3parse.levels.world_map import WorldMap
-from smb3parse.util.rom import Rom
+from smb3parse.util.rom import Rom, INESHeader
 
 root_dir = Path(__file__).parent.parent.parent
 
@@ -25,7 +25,8 @@ def rom():
         )
 
     with open(test_rom_path, "rb") as rom_file:
-        yield Rom(bytearray(rom_file.read()))
+        data = bytearray(rom_file.read())
+        yield Rom(data, INESHeader.from_buffer_copy(data))
 
 
 @pytest.fixture

--- a/smb3parse/tests/conftest.py
+++ b/smb3parse/tests/conftest.py
@@ -17,8 +17,8 @@ def cd_to_repo_root():
     chdir(root_dir)
 
 
-@pytest.fixture()
-def rom():
+@pytest.fixture
+def rom() -> Rom:
     if not test_rom_path.exists():
         raise ValueError(
             f"To run the test suite, place a US SMB3 Rom named '{test_rom_path}' in the root of the repository."
@@ -27,6 +27,15 @@ def rom():
     with open(test_rom_path, "rb") as rom_file:
         data = bytearray(rom_file.read())
         yield Rom(data, INESHeader.from_buffer_copy(data))
+
+
+@pytest.fixture
+def extended_rom(rom) -> Rom:
+    data = bytearray(rom._data)
+
+    # change amount of PRGs to simulate expanded rom
+    data[4] += 1
+    yield Rom(data, INESHeader.from_buffer_copy(data))
 
 
 @pytest.fixture

--- a/smb3parse/tests/unit_tests/test_rom.py
+++ b/smb3parse/tests/unit_tests/test_rom.py
@@ -31,3 +31,20 @@ def test_int():
 
     for offset, number in enumerate(numbers):
         assert rom.int(offset) == number
+
+
+def test_header(rom):
+    assert rom._header.magic == b"NES\x1A"
+    assert rom._header.prg_units == 0x10
+    assert rom._header.chr_units == 0x10
+    assert rom._header.flags6 == b"\x40"
+
+    assert rom._header.prg_size == 0x40000
+    assert rom._header.chr_size == 0x20000
+
+
+def test_header_extended(rom, extended_rom):
+    assert rom.prg_normalize(0x30010) == 0x30010
+    assert rom.prg_normalize(0x40010) == 0x40010
+    assert extended_rom.prg_normalize(0x30010) == 0x30010
+    assert extended_rom.prg_normalize(0x40010) == 0x40010 + INESHeader.PRG_UNIT_SIZE

--- a/smb3parse/tests/unit_tests/test_rom.py
+++ b/smb3parse/tests/unit_tests/test_rom.py
@@ -1,10 +1,11 @@
-from smb3parse.util.rom import Rom
+from smb3parse.util.rom import Rom, INESHeader
 
 
 def test_find():
-    rom_bytes = bytearray(b"\x00\x01\x02\x03\x04\x05\x06\x00")
+    rom_bytes = bytearray(b"\x00\x01\x02\x03\x04\x05\x06\x00\xff\xff\xff\xff\xff\xff\xff\xff")
+    header = INESHeader.from_buffer_copy(rom_bytes)
 
-    rom = Rom(rom_bytes)
+    rom = Rom(rom_bytes, header)
 
     assert rom.find(b"\x00") == 0
     assert rom.find(b"\x00", 1) == 7
@@ -12,19 +13,21 @@ def test_find():
 
 
 def test_little_endian():
-    rom_bytes = bytearray(b"\x00\x01\x02\x03\x04\x05\x06\x00")
+    rom_bytes = bytearray(b"\x00\x01\x02\x03\x04\x05\x06\x00\xff\xff\xff\xff\xff\xff\xff\xff")
+    header = INESHeader.from_buffer_copy(rom_bytes)
 
-    rom = Rom(rom_bytes)
+    rom = Rom(rom_bytes, header)
 
     assert rom.little_endian(0) == (0x01 << 8) + 0x00
     assert rom.little_endian(6) == (0x00 << 8) + 0x06
 
 
 def test_int():
-    rom_bytes = bytearray(b"\x00\x01\x02\x03\x04\x1f")
+    rom_bytes = bytearray(b"\x00\x01\x02\x03\x04\x1f\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff")
+    header = INESHeader.from_buffer_copy(rom_bytes)
     numbers = [0, 1, 2, 3, 4, 0x1F]
 
-    rom = Rom(rom_bytes)
+    rom = Rom(rom_bytes, header)
 
     for offset, number in enumerate(numbers):
         assert rom.int(offset) == number

--- a/smb3parse/util/rom.py
+++ b/smb3parse/util/rom.py
@@ -1,23 +1,71 @@
+from ctypes import Structure, c_char, c_ubyte
 from smb3parse.util import little_endian
+from smb3parse.constants import BASE_OFFSET
+
+class INESHeader(Structure):
+    _fields_ = [
+        ("magic", c_char * 4),
+        ("prg_units", c_ubyte),
+        ("chr_units", c_ubyte),
+        ("flags6", c_char),
+        ("unused_flags", c_char * 4),
+        ("unused_pad", c_char * 5)
+    ]
+    PRG_UNIT_SIZE = 0x4000
+    CHR_UNIT_SIZE = 0x2000
+
+    @property
+    def prg_size(self):
+        return self.prg_units * INESHeader.PRG_UNIT_SIZE
+
+    @property
+    def chr_size(self):
+        return self.chr_units * INESHeader.CHR_UNIT_SIZE
 
 
 class Rom:
-    def __init__(self, rom_data: bytearray):
+    VANILLA_PRG_SIZE = 0x40000
+
+    def __init__(self, rom_data: bytearray, header: INESHeader):
         self._data = rom_data
+        self._header = header
+
+    def prg_normalize(self, offset: int) -> int:
+        """ Takes a vanilla ROM PRG offset and returns a
+        new offset that is correct for the current ROM's
+        PRG size
+
+        IMPORTANT: This method is not idempotent! You cannot
+        call this multiple times giving it resulting offsets
+        from previous calls to it.
+        """
+        # Only prg030 and prg031 are modified in an expanded ROM,
+        # so offsets to other banks should stay the same.
+        # Offsets to CHR region (offsets > vanilla prg size)
+        # also need to be corrected.
+        if (offset < (BASE_OFFSET + (30 * 0x2000))):
+            return offset
+        # Otherwise, we need to normalize this bank 30 or 31 or CHR
+        # offset to the correct bank based on PRG size
+        return self._header.prg_size - (Rom.VANILLA_PRG_SIZE - offset)
 
     def little_endian(self, offset: int) -> int:
+        offset = self.prg_normalize(offset)
         return little_endian(self._data[offset : offset + 2])
 
     def write_little_endian(self, offset: int, integer: int):
+        offset = self.prg_normalize(offset)
         right_byte = (integer & 0xFF00) >> 8
         left_byte = integer & 0x00FF
 
         self.write(offset, bytes([left_byte, right_byte]))
 
-    def read(self, offset: int, length: int) -> bytearray:
+    def read(self, offset: int, length: int) -> bytes:
+        offset = self.prg_normalize(offset)
         return self._data[offset : offset + length]
 
     def write(self, offset: int, data: bytes):
+        offset = self.prg_normalize(offset)
         self._data[offset : offset + len(data)] = data
 
     def find(self, byte: bytes, offset: int = 0) -> int:

--- a/smb3parse/util/rom.py
+++ b/smb3parse/util/rom.py
@@ -2,6 +2,7 @@ from ctypes import Structure, c_char, c_ubyte
 from smb3parse.util import little_endian
 from smb3parse.constants import BASE_OFFSET
 
+
 class INESHeader(Structure):
     _fields_ = [
         ("magic", c_char * 4),
@@ -9,7 +10,7 @@ class INESHeader(Structure):
         ("chr_units", c_ubyte),
         ("flags6", c_char),
         ("unused_flags", c_char * 4),
-        ("unused_pad", c_char * 5)
+        ("unused_pad", c_char * 5),
     ]
     PRG_UNIT_SIZE = 0x4000
     CHR_UNIT_SIZE = 0x2000
@@ -31,7 +32,7 @@ class Rom:
         self._header = header
 
     def prg_normalize(self, offset: int) -> int:
-        """ Takes a vanilla ROM PRG offset and returns a
+        """Takes a vanilla ROM PRG offset and returns a
         new offset that is correct for the current ROM's
         PRG size
 
@@ -43,7 +44,7 @@ class Rom:
         # so offsets to other banks should stay the same.
         # Offsets to CHR region (offsets > vanilla prg size)
         # also need to be corrected.
-        if (offset < (BASE_OFFSET + (30 * 0x2000))):
+        if offset < (BASE_OFFSET + (30 * 0x2000)):
             return offset
         # Otherwise, we need to normalize this bank 30 or 31 or CHR
         # offset to the correct bank based on PRG size

--- a/smb3parse/util/rom.py
+++ b/smb3parse/util/rom.py
@@ -40,15 +40,16 @@ class Rom:
         call this multiple times giving it resulting offsets
         from previous calls to it.
         """
-        # Only prg030 and prg031 are modified in an expanded ROM,
-        # so offsets to other banks should stay the same.
-        # Offsets to CHR region (offsets > vanilla prg size)
-        # also need to be corrected.
+        # data in expanded Roms is inserted between PRG29 and PRG30
+        # (0-indexed); so any offset, that goes beyond PRG29 needs
+        # to be adjusted by adding however much data was inserted
         if offset < (BASE_OFFSET + (30 * 0x2000)):
             return offset
-        # Otherwise, we need to normalize this bank 30 or 31 or CHR
+
+        # we need to normalize this bank 30 or 31 or CHR
         # offset to the correct bank based on PRG size
-        return self._header.prg_size - (Rom.VANILLA_PRG_SIZE - offset)
+        no_bytes_added_to_rom = self._header.prg_size - Rom.VANILLA_PRG_SIZE
+        return offset + no_bytes_added_to_rom
 
     def little_endian(self, offset: int) -> int:
         offset = self.prg_normalize(offset)


### PR DESCRIPTION
# Overview

Closes #67 .

This pull request implements reading the ROM's iNES header in order to be aware of the size of the PRG data. The PRG size defines where the CHR data will be found as well as where the critical, "unmovable" banks within SMB3 are found.

Because Foundry uses hard-coded offsets into these banks to read some game data, those offsets must be modified for expanded ROMs.

# Added Dependencies

`ctypes` (python built-in), untested with the `.exe` pyinstaller build, but I assume it won't be a problem.

# Overall Design

I added a `class INESHdr` to `File.py`. The static class `ROM` now has an additional static attribute named `header` of type `InesHdr` that is initialized when the static ROM is initialized. An additional `classmethod` was added to ROM called `prg_normalize` that takes a ROM offset value and returns the correct, modified offset based on the size of the PRG read from the iNES header.

I was slightly confused about the difference between the static `ROM` class and the lowercase `rom` class that is actually instantiated. Is there a reason this design was chosen? Would the header data/object better belong in the instantiated lowerclase `rom` object? I thought no, because currently all the data in the ROM is parsed once and stored in the static `ROM` class, so it made more sense to put the parsing of the header to occur once and store it in the static `ROM` class.

# Relevant Technical Details

I used `prg_normalize` on the required offsets to get the correct graphics to load when loading both a vanilla and an expanded ROM. I did not fully go through all the code or all the forms in the GUI to make sure all the graphics were correct, so there may need to be more places where we utilize the PRG size.