### PR TITLE
Find level bg pages

### DIFF
--- a/foundry/game/File.py
+++ b/foundry/game/File.py
@@ -98,3 +98,6 @@ class ROM(Rom):
     def bulk_write(self, data: bytearray, position: int):
         position = self.prg_normalize(position)
         ROM.rom_data[position : position + len(data)] = data
+
+    def search(self, needle: bytes) -> int:
+        return ROM.rom_data.find(needle)

--- a/foundry/game/File.py
+++ b/foundry/game/File.py
@@ -2,11 +2,15 @@ from os.path import basename
 from pathlib import Path
 from typing import Optional
 
-from smb3parse.util.rom import INESHeader, Rom
+from smb3parse.util.rom import INESHeader, Rom, PRG_BANK_SIZE
 
 
 class ROM(Rom):
     MARKER_VALUE = bytes("SMB3FOUNDRY", "ascii")
+    PRG030_INDEX = -2
+    """The index passed to search_bank to search the vanilla prg030 bank, regardless of expanded ROM"""
+    PRG031_INDEX = -1
+    """The index passed to search_bank to search the vanilla prg031 bank, regardless of expanded ROM"""
 
     rom_data = bytearray()
     header: Optional[INESHeader] = None
@@ -99,5 +103,19 @@ class ROM(Rom):
         position = self.prg_normalize(position)
         ROM.rom_data[position : position + len(data)] = data
 
-    def search(self, needle: bytes) -> int:
-        return ROM.rom_data.find(needle)
+    def search(self, needle: bytes, start: int = 0, end: int = None) -> int:
+        end = len(needle) if end is None else end
+        return ROM.rom_data.find(needle, start, end)
+
+    def search_bank(self, needle: bytes, bank: int) -> int:
+        """Search a specific bank given a zero-based bank index.
+        If negative values are used, -1 is the last bank, -2 is the second-to-last bank, etc.
+        """
+        num_prg_banks = ROM.header.prg_size // PRG_BANK_SIZE
+        # Search must be within ROM bounds
+        if (abs(bank) > num_prg_banks) or (bank == num_prg_banks):
+            return -1
+        # Mod here for negative banks (negative indices index from the end)
+        bank = bank % num_prg_banks
+        start = bank * PRG_BANK_SIZE
+        return self.search(needle, start, start + PRG_BANK_SIZE)

--- a/foundry/game/gfx/GraphicsSet.py
+++ b/foundry/game/gfx/GraphicsSet.py
@@ -125,8 +125,8 @@ class GraphicsSet:
             self._read_in_chr_rom_segment(segment, self._data)
 
     def _heuristic_bg_pages(self, bg_page_bytes: bytes, fallback_addr: int) -> int:
-        """Searches through the ROM for the main array responsible for rendering the correct graphics.
-        Currently the heuristics in order of precedence are:
+        """Searches through the ROM's PRG030 bank (second-to-last bank) for the main array responsible
+        for rendering the correct graphics. Currently the heuristics in order of precedence are:
 
         1. Search for the bytes from the stock ROM (given as the bg_page_bytes argument)
             - When changing up the assembly, it's probably rare that this array changes, but it can
@@ -136,7 +136,7 @@ class GraphicsSet:
 
         TODO: Do more/better heuristics than searching the stock bytes.
         """
-        bgpages_addr = ROM().search(bg_page_bytes)
+        bgpages_addr = ROM().search_bank(bg_page_bytes, ROM.PRG030_INDEX)
         if bgpages_addr == -1:
             bgpages_addr = fallback_addr
         return ROM().bulk_read(BG_PAGE_COUNT, bgpages_addr)

--- a/foundry/game/gfx/GraphicsSet.py
+++ b/foundry/game/gfx/GraphicsSet.py
@@ -1,8 +1,12 @@
-from binascii import unhexlify
 from functools import lru_cache
 
 from foundry.game.File import ROM
-from smb3parse.constants import Level_BG_Pages1, Level_BG_Pages2
+from smb3parse.constants import (
+    Level_BG_Pages1,
+    Level_BG_Pages2,
+    STOCK_LEVEL_BG_PAGES1_BYTES,
+    STOCK_LEVEL_BG_PAGES2_BYTES,
+)
 
 CHR_ROM_OFFSET = 0x40010
 CHR_ROM_SEGMENT_SIZE = 0x400
@@ -56,12 +60,8 @@ class GraphicsSet:
 
     def __init__(self, graphic_set_number):
         if not self.GRAPHIC_SET_BG_PAGE_1:
-            self.GRAPHIC_SET_BG_PAGE_1 = self._heuristic_bg_pages(
-                unhexlify(b"0008101c0c58585c5830346e18381c242c5c586c683428"), Level_BG_Pages1
-            )
-            self.GRAPHIC_SET_BG_PAGE_2 = self._heuristic_bg_pages(
-                unhexlify(b"00606060603e605e60606a606060605e2e5e6060607060"), Level_BG_Pages2
-            )
+            self.GRAPHIC_SET_BG_PAGE_1 = self._heuristic_bg_pages(STOCK_LEVEL_BG_PAGES1_BYTES, Level_BG_Pages1)
+            self.GRAPHIC_SET_BG_PAGE_2 = self._heuristic_bg_pages(STOCK_LEVEL_BG_PAGES2_BYTES, Level_BG_Pages2)
 
         self._data = bytearray()
         self._anim_data = []

--- a/smb3parse/constants.py
+++ b/smb3parse/constants.py
@@ -1,3 +1,4 @@
+from binascii import unhexlify
 from collections import defaultdict
 from pathlib import Path
 from typing import Union
@@ -20,6 +21,12 @@ See PAGE_A000_OFFSET. Just with 0xC000 as the implicit offset.
 """
 
 WORLD_MAP_TSA_INDEX = 12
+
+STOCK_LEVEL_BG_PAGES1_BYTES = unhexlify(b"0008101c0c58585c5830346e18381c242c5c586c683428")
+"""The Level_BG_Pages1 byte array from the stock ROM"""
+
+STOCK_LEVEL_BG_PAGES2_BYTES = unhexlify(b"00606060603e605e60606a606060605e2e5e6060607060")
+"""The Level_BG_Pages2 byte array from the stock ROM"""
 
 TILE_LEVEL_1 = 0x03
 TILE_LEVEL_2 = 0x04


### PR DESCRIPTION
The current method of finding the arrays just searches for the stock bytes. If it fails to find those, it falls back to using the hard-coded constant addresses as before.

The way this can still fail is if a hacker added new arrays in a different location and used those but left the original arrays in the ROM.

Closes #143 