### PR TITLE
Use working-directory-independent paths

### DIFF
--- a/foundry/gui/WarningList.py
+++ b/foundry/gui/WarningList.py
@@ -5,6 +5,7 @@ from PySide6.QtCore import QEvent, QRect, Qt, Signal, SignalInstance
 from PySide6.QtGui import QCursor, QFocusEvent
 from PySide6.QtWidgets import QLabel, QVBoxLayout, QWidget
 
+from foundry import root_dir
 from foundry.game import GROUND
 from foundry.game.ObjectDefinitions import GeneratorType
 from foundry.game.gfx.objects import EnemyItem
@@ -216,7 +217,7 @@ class WarningList(QWidget):
         return [enemy for enemy in self.level_ref.level.enemies if enemy.type == enemy_id]
 
     def _build_enemy_clan_dict(self):
-        with open("data/enemy_data.json", "r") as enemy_data_file:
+        with open(root_dir.joinpath("data", "enemy_data.json"), "r") as enemy_data_file:
             enemy_data = json.loads(enemy_data_file.read())
 
             self._enemy_dict.clear()

--- a/smb3parse/util/parser/__init__.py
+++ b/smb3parse/util/parser/__init__.py
@@ -302,7 +302,7 @@ def gen_levels_in_rom(
 
     print("---------------------", level_count, "------------------------")
 
-    level_data = pathlib.Path("data/levels.dat")
+    level_data = pathlib.Path(__file__).parent.parent.parent.joinpath("data", "levels.dat")
 
     missing = 0
     levels: dict[int, set[int]] = defaultdict(set)


### PR DESCRIPTION
This PR fixes the accessing of the data directory by using file-relative Paths and `foundry.root_dir`

After this, you can run the script without having the repo as the working directory

In the `smb3parse` module, I didn't use `root_dir` because that would have imported from `foundry`.
Should I keep it this way or should I import from `foundry`?